### PR TITLE
Fixed app names not displaying correctly

### DIFF
--- a/custom_components/samsungtv_tizen/media_player.py
+++ b/custom_components/samsungtv_tizen/media_player.py
@@ -379,17 +379,18 @@ class SamsungTVDevice(MediaPlayerDevice):
             if self._cloud_state == STATE_OFF:
                 self._state = STATE_OFF
                 return None
-            elif self._cloud_source in ["digitalTv", "TV"]:
-                if self._cloud_channel_name != "" and self._cloud_channel != "":
-                    if self._show_channel_number:
-                        return self._cloud_channel_name + " (" + self._cloud_channel + ")"
-                    else:
+            else:
+                running_app = self._get_running_app()
+                if running_app == "TV/HDMI" and self._cloud_source in ["digitalTv", "TV"]:
+                    if self._cloud_channel_name != "" and self._cloud_channel != "":
+                        if self._show_channel_number:
+                            return self._cloud_channel_name + " (" + self._cloud_channel + ")"
+                        else:
+                            return self._cloud_channel_name
+                    elif self._cloud_channel_name != "":
                         return self._cloud_channel_name
-                elif self._cloud_channel_name != "":
-                    return self._cloud_channel_name
-                elif self._cloud_channel != "":
-                    return self._cloud_channel
-
+                    elif self._cloud_channel != "":
+                        return self._cloud_channel
         return self._source
 
     @property

--- a/custom_components/samsungtv_tizen/media_player.py
+++ b/custom_components/samsungtv_tizen/media_player.py
@@ -284,6 +284,10 @@ class SamsungTVDevice(MediaPlayerDevice):
                         if 'visible' in root:
                             if root['visible']:
                                 return app
+                                
+                for attr, value in self._app_list.items():
+                    if value == self._cloud_channel_name:
+                        return attr
 
         return 'TV/HDMI'
 


### PR DESCRIPTION
fixes jaruba/ha-samsungtv-tizen#31

Some apps do not set the `visible` variable to true when they're being used, so `_get_running_app()` always returns "TV/HDMI". This is actually the case for all apps on my TV, so maybe it depends on the device. But since the cloud channel name is set to the running app's ID, that can also be used to get the appropriate name from the app list.

Also, starting an app does not change the cloud source, so `self._cloud_source in ["digitalTv", "TV"]` in `media_title()` will evaluate to true, even if an app is running. An additional check for running apps fixes this.