### PR TITLE
source_list always available as attribute for Google Home/Alexa/other…

### DIFF
--- a/custom_components/samsungtv_tizen/media_player.py
+++ b/custom_components/samsungtv_tizen/media_player.py
@@ -585,8 +585,6 @@ class SamsungTVDevice(MediaPlayerEntity):
         """List of available input sources."""
         if self._app_list is None:
             self._gen_installed_app_list()
-        if self._power_off_in_progress() or self._state == STATE_OFF:
-            return None
         source_list = []
         source_list.extend(list(self._source_list))
         if self._app_list is not None:


### PR DESCRIPTION
… integrations

Ensure source_list is always available as component attribute so it can be used with Google Assistant/Alexa integration without having to have the component actually turned on.  Right now a sync devices will not sync the input sources properly when TV is off.

I do not know anything removing this code would break and have verified this in my own installation, but please doublecheck.