### PR TITLE
Add function that executes after poweron

### DIFF
--- a/custom_components/samsungtv_tizen/media_player.py
+++ b/custom_components/samsungtv_tizen/media_player.py
@@ -993,10 +993,9 @@ class SamsungTVDevice(MediaPlayerEntity):
             await asyncio.sleep(5)
             _LOGGER.debug("Checking if TV is now on...")
             if self._state == STATE_ON:
-                break
-        await asyncio.sleep(5)
-        if command == "source":
-            self.hass.async_add_job(self.async_select_source, arguments[0])
+                await asyncio.sleep(5)
+                if command == "source":
+                    self.hass.async_add_job(self.async_select_source, arguments[0])
 
     @staticmethod
     def _levenshtein_ratio(s, t):


### PR DESCRIPTION
@jaruba - I have created the function now to support changing input source while tv is currently off. It uses an extra function that turns on tv and repeatedly checks if it was successfully turned on. 

To cover those users with erratic on/off states I ensured:
- The input source operation is executed first (only at the end if current TV state is off the extra function to turn on tv executes)
- The loop to check if tv operation was successful only tries for 3 minutes and stops if unsuccessful within that period

The only downside I see is the input change request command get execute twice for those with wrong on/off state (but only if state changes from off to on within 3 minutes). For me that would be an acceptable edge case...

It has been working successfully now for a week on both my TVs.

Perhaps you can try it out/have a look before we merge to master?