### PR TITLE
Implemented Select Picture Mode (SmartThings)

### DIFF
--- a/custom_components/samsungtv_tizen/api/smartthings.py
+++ b/custom_components/samsungtv_tizen/api/smartthings.py
@@ -33,7 +33,7 @@ COMMAND_PLAY = {"capability": "mediaPlayback", "command": "play"}
 COMMAND_STOP = {"capability": "mediaPlayback", "command": "stop"}
 COMMAND_FAST_FORWARD = {"capability": "mediaPlayback", "command": "fastForward"}
 COMMAND_REWIND = {"capability": "mediaPlayback", "command": "rewind"}
-COMMAND_AUDIO_MODE = {"capability": "custom.soundmode", "command": "setSoundMode"}
+COMMAND_SOUND_MODE = {"capability": "custom.soundmode", "command": "setSoundMode"}
 COMMAND_PICTURE_MODE = {"capability": "custom.picturemode", "command": "setPictureMode"}
 
 DIGITAL_TV = "digitalTv"
@@ -485,7 +485,7 @@ class SmartThingsTV:
             return
         if mode not in self._sound_mode_list:
             raise InvalidSmartThingsSoundMode()
-        data_cmd = _command(COMMAND_AUDIO_MODE, [mode])
+        data_cmd = _command(COMMAND_SOUND_MODE, [mode])
         await self._async_send_command(data_cmd)
         self._sound_mode = mode
 

--- a/custom_components/samsungtv_tizen/const.py
+++ b/custom_components/samsungtv_tizen/const.py
@@ -23,36 +23,36 @@ DOMAIN = "samsungtv_tizen"
 
 WS_PREFIX = "[Home Assistant]"
 
-CONF_APP_LIST = "app_list"
 CONF_APP_LAUNCH_METHOD = "app_launch_method"
+CONF_APP_LIST = "app_list"
 CONF_APP_LOAD_METHOD = "app_load_method"
 CONF_CHANNEL_LIST = "channel_list"
-CONF_DEVICE_NAME = "device_name"
 CONF_DEVICE_MODEL = "device_model"
-CONF_SOURCE_LIST = "source_list"
-CONF_SHOW_CHANNEL_NR = "show_channel_number"
-CONF_WS_NAME = "ws_name"
+CONF_DEVICE_NAME = "device_name"
 CONF_DEVICE_OS = "device_os"
 CONF_LOAD_ALL_APPS = "load_all_apps"
 CONF_POWER_ON_DELAY = "power_on_delay"
 CONF_POWER_ON_METHOD = "power_on_method"
-CONF_USE_ST_CHANNEL_INFO = "use_st_channel_info"
-CONF_USE_ST_STATUS_INFO = "use_st_status_info"
-CONF_USE_MUTE_CHECK = "use_mute_check"
+CONF_SHOW_CHANNEL_NR = "show_channel_number"
+CONF_SOURCE_LIST = "source_list"
 CONF_SYNC_TURN_OFF = "sync_turn_off"
 CONF_SYNC_TURN_ON = "sync_turn_on"
+CONF_USE_MUTE_CHECK = "use_mute_check"
+CONF_USE_ST_CHANNEL_INFO = "use_st_channel_info"
+CONF_USE_ST_STATUS_INFO = "use_st_status_info"
 CONF_WOL_REPEAT = "wol_repeat"
+CONF_WS_NAME = "ws_name"
 
 # obsolete
 CONF_UPDATE_METHOD = "update_method"
 CONF_UPDATE_CUSTOM_PING_URL = "update_custom_ping_url"
 CONF_SCAN_APP_HTTP = "scan_app_http"
 
+DEFAULT_APP = "TV/HDMI"
 DEFAULT_PORT = 8001
-DEFAULT_TIMEOUT = 5
 DEFAULT_POWER_ON_DELAY = 30
 DEFAULT_SOURCE_LIST = {"TV": "KEY_TV", "HDMI": "KEY_HDMI"}
-DEFAULT_APP = "TV/HDMI"
+DEFAULT_TIMEOUT = 5
 
 MAX_WOL_REPEAT = 5
 
@@ -64,6 +64,7 @@ RESULT_ST_MULTI_DEVICES = "st_multiple_device"
 RESULT_SUCCESS = "success"
 RESULT_WRONG_APIKEY = "wrong_api_key"
 
+SERVICE_SELECT_PICTURE_MODE = "select_picture_mode"
 SERVICE_SET_ART_MODE = "set_art_mode"
 
 STD_APP_LIST = {

--- a/custom_components/samsungtv_tizen/media_player.py
+++ b/custom_components/samsungtv_tizen/media_player.py
@@ -1,7 +1,7 @@
 """Support for interface with an Samsung TV."""
 import asyncio
-import logging
 import json
+import logging
 import os
 from datetime import datetime, timedelta
 from socket import error as socketError
@@ -35,8 +35,8 @@ from homeassistant.components.media_player.const import (
     SUPPORT_PLAY,
     SUPPORT_PLAY_MEDIA,
     SUPPORT_PREVIOUS_TRACK,
-    SUPPORT_SELECT_SOURCE,
     SUPPORT_SELECT_SOUND_MODE,
+    SUPPORT_SELECT_SOURCE,
     SUPPORT_STOP,
     SUPPORT_TURN_OFF,
     SUPPORT_TURN_ON,
@@ -46,17 +46,17 @@ from homeassistant.components.media_player.const import (
 )
 
 from homeassistant.const import (
+    CONF_API_KEY,
     CONF_BROADCAST_ADDRESS,
+    CONF_DEVICE_ID,
     CONF_HOST,
     CONF_ID,
     CONF_MAC,
     CONF_NAME,
     CONF_PORT,
-    CONF_DEVICE_ID,
-    CONF_TIMEOUT,
-    CONF_API_KEY,
     CONF_SERVICE,
     CONF_SERVICE_DATA,
+    CONF_TIMEOUT,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
@@ -64,29 +64,30 @@ from homeassistant.const import (
 
 from .const import (
     DOMAIN,
-    CONF_APP_LIST,
     CONF_APP_LAUNCH_METHOD,
+    CONF_APP_LIST,
     CONF_APP_LOAD_METHOD,
     CONF_CHANNEL_LIST,
-    CONF_DEVICE_NAME,
     CONF_DEVICE_MODEL,
+    CONF_DEVICE_NAME,
     CONF_DEVICE_OS,
     CONF_POWER_ON_DELAY,
     CONF_POWER_ON_METHOD,
     CONF_SHOW_CHANNEL_NR,
     CONF_SOURCE_LIST,
+    CONF_SYNC_TURN_OFF,
+    CONF_SYNC_TURN_ON,
     CONF_USE_MUTE_CHECK,
     CONF_USE_ST_CHANNEL_INFO,
     CONF_USE_ST_STATUS_INFO,
-    CONF_SYNC_TURN_OFF,
-    CONF_SYNC_TURN_ON,
     CONF_WOL_REPEAT,
     CONF_WS_NAME,
-    DEFAULT_TIMEOUT,
-    DEFAULT_SOURCE_LIST,
     DEFAULT_APP,
     DEFAULT_POWER_ON_DELAY,
+    DEFAULT_SOURCE_LIST,
+    DEFAULT_TIMEOUT,
     MAX_WOL_REPEAT,
+    SERVICE_SELECT_PICTURE_MODE,
     SERVICE_SET_ART_MODE,
     STD_APP_LIST,
     WS_PREFIX,
@@ -101,9 +102,11 @@ except ImportError:
     from homeassistant.components.media_player import MediaPlayerDevice as MediaPlayerEntity
 
 ATTR_ART_MODE_STATUS = "art_mode_status"
-ATTR_DEVICE_NAME = "device_name"
 ATTR_DEVICE_MODEL = "device_model"
+ATTR_DEVICE_NAME = "device_name"
 ATTR_IP_ADDRESS = "ip_address"
+ATTR_PICTURE_MODE = "picture_mode"
+ATTR_PICTURE_MODE_LIST = "picture_mode_list"
 
 CMD_OPEN_BROWSER = "open_browser"
 CMD_RUN_APP = "run_app"
@@ -169,7 +172,13 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     async_add_entities([SamsungTVDevice(config, entry_id, session)], True)
 
+    # register services
     platform = entity_platform.current_platform.get()
+    platform.async_register_entity_service(
+        SERVICE_SELECT_PICTURE_MODE,
+        {vol.Required(ATTR_PICTURE_MODE): cv.string},
+        "async_select_picture_mode",
+    )
     platform.async_register_entity_service(
         SERVICE_SET_ART_MODE,
         None,
@@ -1327,8 +1336,15 @@ class SamsungTVDevice(MediaPlayerEntity):
 
     async def async_select_sound_mode(self, sound_mode):
         """Select sound mode."""
-        if self._st:
-            await self._st.async_set_sound_mode(sound_mode)
+        if not self._st:
+            raise NotImplementedError()
+        await self._st.async_set_sound_mode(sound_mode)
+
+    async def async_select_picture_mode(self, picture_mode):
+        """Select picture mode."""
+        if not self._st:
+            raise NotImplementedError()
+        await self._st.async_set_picture_mode(picture_mode)
 
     @property
     def device_info(self):
@@ -1363,6 +1379,14 @@ class SamsungTVDevice(MediaPlayerEntity):
             data.update({
                 ATTR_ART_MODE_STATUS: STATE_ON if status_on else STATE_OFF
             })
+        if self._st:
+            picture_mode = self._st.picture_mode
+            picture_mode_list = self._st.picture_mode_list
+            if picture_mode:
+                data[ATTR_PICTURE_MODE] = picture_mode
+            if picture_mode_list:
+                data[ATTR_PICTURE_MODE_LIST] = picture_mode_list
+
         return data
 
     def _will_remove_from_hass(self):

--- a/custom_components/samsungtv_tizen/services.yaml
+++ b/custom_components/samsungtv_tizen/services.yaml
@@ -1,5 +1,17 @@
+select_picture_mode:
+  description: Send the samsung TV the command to change picture mode.
+  fields:
+    entity_id:
+      description: Name of the target entity
+      example: "media_player.tv"
+    picture_mode:
+      description: >
+        Name of the picture mode to switch to. Possible options can be found in the
+        picture_mode_list state attribute.
+      example: "Standard"
+
 set_art_mode:
-  description: Set art mode.
+  description: Send the samsung TV the command to set art mode.
   fields:
     entity_id:
       description: Name of the target entity


### PR DESCRIPTION
@jaruba and @Screwdgeh,

with this last PR;

- Implemented `select_picture_mode` service (SmartThings only): for this I created a new dedicated service, because this feature is not natively supported by `media_player` entity. In previous PR was already implemented support for `sound_mode`, but this is managed using native `media_player` attributes and related service.
- Refactor SmartThings implementation: I was thinking about this change from some time, just to have the list of ST commands more readable. 
- Sort constant import and definition: just for code order

I do not directly merge this PR just to let you have a look on the change, but you can merge when you want and go ahead with next step (logo). Or if you have some comment, we can discuss...

I will not add new features to my repo from now, just will fix eventual issue and create related PR.
