### PR TITLE
Remove hard pinning requirement from manifest.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+
+.idea/ha-samsungtv-smart.iml
+.idea/inspectionProfiles/profiles_settings.xml
+.idea/inspectionProfiles/Project_Default.xml
+.idea/misc.xml
+.idea/modules.xml
+.idea/vcs.xml
+.idea/workspace.xml

--- a/custom_components/samsungtv_tizen/manifest.json
+++ b/custom_components/samsungtv_tizen/manifest.json
@@ -3,12 +3,12 @@
   "name": "SamsungTV Tizen",
   "documentation": "https://github.com/jaruba/ha-samsungtv-tizen",
   "requirements": [
-    "websocket-client==0.56.0",
-    "wakeonlan==1.1.6",
-    "numpy==1.21.1"
+    "websocket-client>=0.56.0",
+    "wakeonlan>=2.0.0",
+    "numpy>=1.19.2"
   ],
   "dependencies": [],
   "codeowners": ["@jaruba"],
   "homeassistant": "0.99.3",
-  "version": "1.5.9"
+  "version": "1.5.10"
 }


### PR DESCRIPTION
I suggest to remove library "hard-pinning" in `manifest.json` 

- `websocket-client` v0.56.0 is very old version and v0.58.0 also include a breaking change, that anyway do not impact this component. We can leave this as mininum version but allow new one to not impact installation of other integration
- `wakeonlan` is on version 2.0.0 in HA. Not big changes, just bug fix, better to set v2.x as minimum
- `numpy` is on version 1.21.1 in HA, but we know that 1.19.2 here is ok, so I would leave 1.19.2 as min but allow new version as done for `websocket-client`

I could also commit this PR and create new release but I'd like at least an agreement before.