### PR TITLE
Bump NumPy to version 1.23.0

### DIFF
--- a/custom_components/samsungtv_tizen/manifest.json
+++ b/custom_components/samsungtv_tizen/manifest.json
@@ -5,7 +5,7 @@
   "requirements": [
     "websocket-client==0.56.0",
     "wakeonlan==1.1.6",
-    "numpy==1.21.1"
+    "numpy==1.23.0"
   ],
   "dependencies": [],
   "codeowners": ["@jaruba"],


### PR DESCRIPTION
Fix for Home Assistant error `Cannot install numpy==1.21.1 because these package versions have conflicting dependencies`